### PR TITLE
add: cython as gitlines option

### DIFF
--- a/main.py
+++ b/main.py
@@ -569,6 +569,7 @@ class Commands(commands.Cog):
         # TODO: better multi-line support
         lang_comments = {
             "py": {"single": "#", "multi": ('"""', "'''")},  # wrong but okay for now
+            "pyx": {"single": "#", "multi": ('"""', "'''")},
             #'go': {'single': '//', 'multi': ()},
             #'js': {'single': '//', 'multi': ()},
             #'ts': {'single': '//', 'multi': ()},


### PR DESCRIPTION
Cython follows the same syntax as Python in regards of comments. This change reuses the Python count logic for Cython.